### PR TITLE
[MODIFIED] スタックにしながらヘッダーを消した

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -2,16 +2,8 @@ import { Stack } from 'expo-router'
 
 const Layout = (): JSX.Element => {
     return <Stack screenOptions={{
-        headerStyle: {
-            backgroundColor: '#467FD3'
-        },
-        headerTintColor: '#ffffff',
-        headerTitle: 'Memo App',
         headerBackTitle: 'Back',
-        headerTitleStyle: {
-            fontSize: 22,
-            fontWeight: 'bold'
-        }
+        headerShown: false
     }} />
 }
 

--- a/src/app/auth/login.tsx
+++ b/src/app/auth/login.tsx
@@ -50,7 +50,7 @@ const Login = (): JSX.Element => {
                 <Button onPress={() => { handlePress(email, password) }} label='Submit' />
                 <View style={styles.footer}>
                     <Text style={styles.footerText}>Not registered?</Text>
-                    <Link href='/auth/signup' asChild replace>
+                    <Link href='/auth/signup' asChild>
                         <TouchableOpacity>
                             <Text style={styles.footerLink}>Sign up here!</Text>
                         </TouchableOpacity>

--- a/src/app/auth/signup.tsx
+++ b/src/app/auth/signup.tsx
@@ -48,7 +48,7 @@ const SignUp = (): JSX.Element => {
                 <Button onPress={() => { handlePress(email, password) }} label='Submit' />
                 <View style={styles.footer}>
                     <Text style={styles.footerText}>Already registered?</Text>
-                    <Link href='/auth/login' asChild replace>
+                    <Link href='/auth/login' asChild>
                         <TouchableOpacity>
                             <Text style={styles.footerLink}>Log In</Text>
                         </TouchableOpacity>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface Changes**
	- Removed the header from the Memo App layout, streamlining the user interface.
  
- **Navigation Enhancements**
	- Updated the login and signup navigation behavior to allow users to return to previous pages after transitioning between them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->